### PR TITLE
fix: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,5 +1,8 @@
 name: Build and Test
 
+permissions:
+  contents: read
+
 on: 
   workflow_dispatch:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@
 # - Checkout is 'shallow' despite fetch-depth: 0
 # - Command failed: C:\hostedtoolcache\windows\GitVersion.Tool\6.0.2\dotnet-gitversion.exe with no error message  
 name: Release
+permissions:
+  contents: read
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/transmitly/transmitly-channel-provider-firebase/security/code-scanning/2](https://github.com/transmitly/transmitly-channel-provider-firebase/security/code-scanning/2)

To fix the problem, add a `permissions` block at the top level of the workflow (before `jobs:`), which sets the GITHUB_TOKEN permissions to the minimum required for this workflow. Since the workflow only reads code and pushes packages using secrets (not the GITHUB_TOKEN), the minimal permission needed is `contents: read`. This should be inserted after the workflow `name:` and before `on:` or just after `on:`. No changes are needed within the job itself or steps, as the publishing steps use explicit secrets. This change ensures that the workflow adheres to the principle of least privilege without affecting existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
